### PR TITLE
WA ZeroDivisionError in EX score calculation

### DIFF
--- a/boogiestats/boogie_api/models.py
+++ b/boogiestats/boogie_api/models.py
@@ -315,4 +315,7 @@ class Score(models.Model):
             + self.mines_hit * weights["mine"]
         )
 
-        return max(0, math.floor(points / total_possible * 10000) / 100)
+        try:
+            return max(0, math.floor(points / total_possible * 10000) / 100)
+        except ZeroDivisionError:
+            return 0


### PR DESCRIPTION
Some skins submit invalid scores (missing steps stats) when Auto Play mode was initially enabled and later disabled.

![image](https://github.com/florczakraf/boogie-stats/assets/9034451/c57361ae-1bc1-4dad-b253-12314e3a7726)
