### PR TITLE
Automatically check pending migrations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,7 +23,7 @@ jobs:
         run: |
           pytest -sv
 
-  blacken:
+  black:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -47,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           pip install --upgrade pip
@@ -63,7 +62,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           pip install --upgrade pip
@@ -79,7 +78,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,3 +86,21 @@ jobs:
       - name: Run bandit
         run: |
           bandit --configfile bandit.yml -r boogiestats/
+
+  pending-migrations:
+    runs-on: ubuntu-latest
+    env:
+      DJANGO_SETTINGS_MODULE: boogiestats.boogiestats.settings
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install .[dev]
+      - name: Check pending migrations
+        run: |
+          django-admin makemigrations --check


### PR DESCRIPTION
In order to avoid situations like #137 in the future, we can add a check against pending migrations to the CI pipeline.

closes #138 