### PR TITLE
Improve rival selection in profile edit view

### DIFF
--- a/boogiestats/boogie_ui/forms.py
+++ b/boogiestats/boogie_ui/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from formset.widgets import DualSelector
 
 from boogiestats.boogie_api.models import Player
 
@@ -11,6 +12,11 @@ class EditPlayerForm(forms.ModelForm):
         widget=forms.PasswordInput(attrs={"placeholder": "First 32 characters of your new GS API key"}),
         help_text="Fill this when you've generated a new GS API key",
         label="New GrooveStats API key",
+    )
+    rivals = forms.models.ModelMultipleChoiceField(
+        queryset=Player.objects.all(),
+        widget=DualSelector(search_lookup=["name__icontains", "machine_tag__icontains"]),
+        required=False,
     )
 
     class Meta:

--- a/boogiestats/boogie_ui/views.py
+++ b/boogiestats/boogie_ui/views.py
@@ -18,6 +18,8 @@ from django.views import generic
 from django.views.decorators.http import require_POST
 from redis import ResponseError
 from redis.commands.search.query import Query
+from formset.views import FormViewMixin, IncompleteSelectResponseMixin
+
 
 from boogiestats.boogie_api.models import Score, Player, Song
 from boogiestats.boogie_api.utils import get_redis, set_sentry_user
@@ -483,7 +485,9 @@ class SuccessMessageExtraTagsMixin:
         return self.success_message % cleaned_data
 
 
-class EditPlayerView(LoginRequiredMixin, SuccessMessageExtraTagsMixin, generic.UpdateView):
+class EditPlayerView(
+    LoginRequiredMixin, SuccessMessageExtraTagsMixin, FormViewMixin, IncompleteSelectResponseMixin, generic.UpdateView
+):
     login_url = "/login/"
     template_name = "boogie_ui/player_update.html"
     form_class = EditPlayerForm

--- a/boogiestats/boogiestats/settings.py
+++ b/boogiestats/boogiestats/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     "mathfilters",
     "django_bootstrap_icons",
     "django_prometheus",
+    "formset",
     "boogiestats.boogie_api",
     "boogiestats.boogie_ui",
 ]

--- a/boogiestats/templates/boogie_ui/player_update.html
+++ b/boogiestats/templates/boogie_ui/player_update.html
@@ -1,14 +1,23 @@
 {% extends "boogie_ui/root.html" %}
+{% load static %}
+{% load formsetify %}
+{% block head_extras %}
+    <link href="{% static 'formset/css/bootstrap5-extra.css' %}"
+          rel="stylesheet">
+    <link href="{% static 'formset/css/collections.css' %}" rel="stylesheet">
+    <script type="module" src="{% static 'formset/js/django-formset.js' %}"></script>
+{% endblock head_extras %}
 {% block title %}
     Edit Profile
 {% endblock title %}
 {% block content %}
     <h2>Edit Profile</h2>
-    <form method="post">
-        {% csrf_token %}
-        <table>
-            {{ form.as_table }}
-        </table>
-        <input class="btn btn-primary" type="submit" value="Update" />
-    </form>
+    <div class="w-50 p-3">
+        <django-formset endpoint="{{ request.path }}"  csrf-token="{{ csrf_token }}">
+        {% render_form form "bootstrap" field_classes="row mb-3" label_classes="col-sm-3" control_classes="col-sm-9" %}
+        <button type="button"
+                df-click="disable -> submit -> proceed"
+                class="btn btn-primary">Submit</button>
+        </django-formset>
+    </div>
 {% endblock content %}

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setuptools.setup(
         "django-prometheus >=2.3.1, <3",
         "prometheus-client == 0.18.0",
         "django-ipware >=5.0.2, <6",
+        "django-formset >=1.3.8, <2",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
![image](https://github.com/florczakraf/boogie-stats/assets/9034451/c8d7d09c-ea9b-4f21-a115-522d576be2c5)

The used library also has a support for ordered many-to-many relations so we might think about using that in the future to let people manually order their rivals

closes #96 