### PR TITLE
Mobile-friendly frontend improvements

### DIFF
--- a/boogiestats/static/boogie_ui/boogiestats.js
+++ b/boogiestats/static/boogie_ui/boogiestats.js
@@ -1,9 +1,9 @@
 const dateOptions = {
     hour: "numeric",
     minute: "numeric",
-    weekday: "long",
+    weekday: "short",
     year: "numeric",
-    month: "long",
+    month: "short",
     day: "numeric",
     hourCycle: "h23",
 };

--- a/boogiestats/templates/boogie_ui/footer.html
+++ b/boogiestats/templates/boogie_ui/footer.html
@@ -1,4 +1,4 @@
-<footer class="text-center text-lg-start bg-light text-muted bg-body-secondary">
+<footer class="text-center text-lg-start bg-light text-muted bg-body-secondary mt-auto">
     <div class="text-center">
         All data is in Public Domain –
         <a class="text-reset fw-bold"

--- a/boogiestats/templates/boogie_ui/header.html
+++ b/boogiestats/templates/boogie_ui/header.html
@@ -1,6 +1,6 @@
 {% load static %}
 {% load bootstrap_icons %}
-<nav class="navbar navbar-expand-md bg-dark-subtle">
+<nav class="navbar navbar-expand-lg bg-dark-subtle sticky-top">
     <div class="container-fluid">
         <a class="navbar-brand p-0" href="{% url "index" %}">
             {% if BS_LOGO_PATH %}
@@ -23,40 +23,40 @@
         </button>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                <li class="nav-item">
+                <li class="nav-item text-nowrap">
                     <a class="nav-link" href="{% url "index" %}">Home</a>
                 </li>
-                <li class="nav-item">
+                <li class="nav-item text-nowrap">
                     <a class="nav-link" href="{% url "players" %}">Players</a>
                 </li>
-                <li class="nav-item">
+                <li class="nav-item text-nowrap">
                     <a class="nav-link" href="{% url "songs" %}">Songs</a>
                 </li>
-                <li class="nav-item">
+                <li class="nav-item text-nowrap">
                     <a class="nav-link" href="{% url "scores" %}">Scores</a>
                 </li>
-                <li class="nav-item">
+                <li class="nav-item text-nowrap">
                     <a class="nav-link" href="{% url "manual" %}">User Manual</a>
                 </li>
-                <li class="nav-item">
+                <li class="nav-item text-nowrap">
                     <a class="nav-link" href="{% url "my-profile" %}">My Profile</a>
                 </li>
-                <li class="nav-item">
+                <li class="nav-item text-nowrap">
                     <a class="nav-link" href="{% url "edit" %}">Edit Profile</a>
                 </li>
                 {% if user.is_authenticated %}
-                    <li class="nav-item">
+                    <li class="nav-item text-nowrap">
                         <a class="nav-link" href="{% url "logout" %}">Logout</a>
                     </li>
                 {% endif %}
-                <li class="nav-item">
+                <li class="nav-item text-nowrap">
                     <a href="#"
                        class="nav-link"
                        id="darkModeSwitch"
                        data-bs-toggle="tooltip"
                        title="Switch between light and dark theme.">{% bs_icon "sun" %}/{% bs_icon "moon" %}</a>
                 </li>
-                <li class="nav-item">
+                <li class="nav-item text-nowrap">
                     <div class="nav-link"
                          data-bs-toggle="tooltip"
                          title="Switch between ITG and EX leaderboards on the website. If you want to change your in-game leaderboards, go to Edit Profile.">

--- a/boogiestats/templates/boogie_ui/index.html
+++ b/boogiestats/templates/boogie_ui/index.html
@@ -7,75 +7,79 @@
 {% block content %}
     <h2>Latest Scores</h2>
     {% if latest_scores %}
-        <table class="table table-striped">
-            <thead class="bg-body-secondary">
-                <tr>
-                    <th scope="col" class="w-1 text-nowrap">Submission Date</th>
-                    <th scope="col" class="w-100 text-nowrap">Song</th>
-                    <th scope="col" class="w-1 text-nowrap">{{ lb_display_name }} Score</th>
-                    <th scope="col" class="w-1 text-nowrap">Player</th>
-                </tr>
-            </thead>
-            <tbody class="align-middle">
-                {% for score in latest_scores %}
+        <div class="table-responsive">
+            <table class="table table-striped">
+                <thead class="bg-body-secondary">
                     <tr>
-                        <td class="text-nowrap">
-                            {% with datetime=score.submission_date %}
-                                {% include "boogie_ui/convert_timestamp.html" %}
-                            {% endwith %}
-                        </td>
-                        <td>
-                            {% with song=score.song %}
-                                {% include "boogie_ui/song_link.html" %}
-                            {% endwith %}
-                        </td>
-                        <td class="text-nowrap">{% include "boogie_ui/score_with_judgments.html" %}</td>
-                        <td class="text-nowrap">
-                            <a href="{% url "player" player_id=score.player.id %}">{{ score.player.name }}</a>
-                        </td>
+                        <th scope="col" class="w-1 text-nowrap">Submission Date</th>
+                        <th scope="col" class="w-100 text-nowrap">Song</th>
+                        <th scope="col" class="w-1 text-nowrap">{{ lb_display_name }} Score</th>
+                        <th scope="col" class="w-1 text-nowrap">Player</th>
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
+                <tbody class="align-middle">
+                    {% for score in latest_scores %}
+                        <tr>
+                            <td class="text-nowrap">
+                                {% with datetime=score.submission_date %}
+                                    {% include "boogie_ui/convert_timestamp.html" %}
+                                {% endwith %}
+                            </td>
+                            <td class="text-nowrap">
+                                {% with song=score.song %}
+                                    {% include "boogie_ui/song_link.html" %}
+                                {% endwith %}
+                            </td>
+                            <td class="text-nowrap">{% include "boogie_ui/score_with_judgments.html" %}</td>
+                            <td class="text-nowrap">
+                                <a href="{% url "player" player_id=score.player.id %}">{{ score.player.name }}</a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
     {% else %}
         <p>No scores are available.</p>
     {% endif %}
     <h2>Recent Player Activity</h2>
     {% if recent_activity and recent_activity.0.latest_score %}
-        <table class="table table-striped">
-            <thead class="bg-body-secondary">
-                <tr>
-                    <th scope="col" class="w-1 text-nowrap">Submission Date</th>
-                    <th scope="col" class="w-100 text-nowrap">Song</th>
-                    <th scope="col" class="w-1 text-nowrap">{{ lb_display_name }} Score</th>
-                    <th scope="col" class="w-1 text-nowrap">Player</th>
-                </tr>
-            </thead>
-            <tbody class="align-middle">
-                {% for player in recent_activity %}
+        <div class="table-responsive">
+            <table class="table table-striped">
+                <thead class="bg-body-secondary">
                     <tr>
-                        <td class="text-nowrap">
-                            {% with datetime=player.latest_score.submission_date %}
-                                {% include "boogie_ui/convert_timestamp.html" %}
-                            {% endwith %}
-                        </td>
-                        <td>
-                            {% with song=player.latest_score.song %}
-                                {% include "boogie_ui/song_link.html" %}
-                            {% endwith %}
-                        </td>
-                        <td class="text-nowrap">
-                            {% with score=player.latest_score %}
-                                {% include "boogie_ui/score_with_judgments.html" %}
-                            {% endwith %}
-                        </td>
-                        <td class="text-nowrap">
-                            <a href="{% url "player" player_id=player.id %}">{{ player.name }}</a>
-                        </td>
+                        <th scope="col" class="w-1 text-nowrap">Submission Date</th>
+                        <th scope="col" class="w-100 text-nowrap">Song</th>
+                        <th scope="col" class="w-1 text-nowrap">{{ lb_display_name }} Score</th>
+                        <th scope="col" class="w-1 text-nowrap">Player</th>
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
+                <tbody class="align-middle">
+                    {% for player in recent_activity %}
+                        <tr>
+                            <td class="text-nowrap">
+                                {% with datetime=player.latest_score.submission_date %}
+                                    {% include "boogie_ui/convert_timestamp.html" %}
+                                {% endwith %}
+                            </td>
+                            <td class="text-nowrap">
+                                {% with song=player.latest_score.song %}
+                                    {% include "boogie_ui/song_link.html" %}
+                                {% endwith %}
+                            </td>
+                            <td class="text-nowrap">
+                                {% with score=player.latest_score %}
+                                    {% include "boogie_ui/score_with_judgments.html" %}
+                                {% endwith %}
+                            </td>
+                            <td class="text-nowrap">
+                                <a href="{% url "player" player_id=player.id %}">{{ player.name }}</a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
     {% else %}
         <p>No recent activity available.</p>
     {% endif %}

--- a/boogiestats/templates/boogie_ui/login.html
+++ b/boogiestats/templates/boogie_ui/login.html
@@ -3,24 +3,21 @@
     Sign In
 {% endblock title %}
 {% block content %}
-    <h2>Sign In</h2>
-    <form action="{% url "login" %}" method="post">
-        {% csrf_token %}
-        {% if next %}<input type="hidden" name="next" value="{{ next }}" />{% endif %}
-        <table>
-            <tr>
-                <th>
-                    <label for="gs_api_key">GS API Key (first 32 characters):</label>
-                </th>
-                <td>
-                    <input type="password"
-                           id="gs_api_key"
-                           name="gs_api_key"
-                           placeholder="First 32 characters of gs-api-key"
-                           maxlength="32" />
-                </td>
-            </tr>
-        </table>
-        <input class="btn btn-primary" type="submit" value="Sign In" />
-    </form>
+    <div class="container">
+        <h2>Sign In</h2>
+        <form action="{% url "login" %}" method="post">
+            {% csrf_token %}
+            {% if next %}<input type="hidden" name="next" value="{{ next }}" />{% endif %}
+            <div class="mb-3">
+                <label class="form-label" for="gs_api_key">GS API Key (first 32 characters):</label>
+                <input class="form-control"
+                       type="password"
+                       id="gs_api_key"
+                       name="gs_api_key"
+                       placeholder="First 32 characters of gs-api-key"
+                       maxlength="32" />
+            </div>
+            <input class="btn btn-primary" type="submit" value="Sign In" />
+        </form>
+    </div>
 {% endblock content %}

--- a/boogiestats/templates/boogie_ui/paginator.html
+++ b/boogiestats/templates/boogie_ui/paginator.html
@@ -1,5 +1,5 @@
 {% if paginator.num_pages > 1 %}
-    <div class="pagination">
+    <div class="pagination my-2">
         <span class="step-links">
             {% if page_obj.has_previous %}
                 <a href="?page=1{% include "boogie_ui/q_parameter.html" %}">« first</a>

--- a/boogiestats/templates/boogie_ui/player.html
+++ b/boogiestats/templates/boogie_ui/player.html
@@ -96,50 +96,52 @@
     </a>
     {% if scores %}
         {% include "boogie_ui/paginator.html" %}
-        <table class="table table-striped">
-            <thead class="bg-body-secondary">
-                <tr>
-                    {% if request.resolver_match.url_name == "player_most_played" %}
-                        <th scope="col" class="w-1 text-nowrap">Play Count ↓</th>
-                    {% endif %}
-                    <th scope="col" class="w-100 text-nowrap">Song</th>
-                    <th scope="col" class="w-1 text-nowrap">Comment</th>
-                    <th scope="col" class="w-1 text-nowrap">
-                        {% if request.resolver_match.url_name == "player" %}
-                            {{ lb_display_name }} Score
-                        {% else %}
-                            {{ lb_display_name }} Highscore
-                        {% endif %}
-                        {% if request.resolver_match.url_name == "player_highscores" %}↓{% endif %}
-                    </th>
-                    <th scope="col" class="w-1 text-nowrap">
-                        Submission Date
-                        {% if request.resolver_match.url_name == "player" %}↓{% endif %}
-                    </th>
-                </tr>
-            </thead>
-            <tbody class="align-middle">
-                {% for score in scores %}
+        <div class="table-responsive">
+            <table class="table table-striped">
+                <thead class="bg-body-secondary">
                     <tr>
                         {% if request.resolver_match.url_name == "player_most_played" %}
-                            <td class="text-nowrap">{{ score.num_scores }}</td>
+                            <th scope="col" class="w-1 text-nowrap">Play Count ↓</th>
                         {% endif %}
-                        <td>
-                            {% with song=score.song %}
-                                {% include "boogie_ui/song_link.html" %}
-                            {% endwith %}
-                        </td>
-                        <td class="text-nowrap">{{ score.comment }}</td>
-                        <td class="text-nowrap">{% include "boogie_ui/score_with_judgments.html" %}</td>
-                        <td class="text-nowrap">
-                            {% with datetime=score.submission_date %}
-                                {% include "boogie_ui/convert_timestamp.html" %}
-                            {% endwith %}
-                        </td>
+                        <th scope="col" class="w-100 text-nowrap">Song</th>
+                        <th scope="col" class="w-1 text-nowrap">Comment</th>
+                        <th scope="col" class="w-1 text-nowrap">
+                            {% if request.resolver_match.url_name == "player" %}
+                                {{ lb_display_name }} Score
+                            {% else %}
+                                {{ lb_display_name }} Highscore
+                            {% endif %}
+                            {% if request.resolver_match.url_name == "player_highscores" %}↓{% endif %}
+                        </th>
+                        <th scope="col" class="w-1 text-nowrap">
+                            Submission Date
+                            {% if request.resolver_match.url_name == "player" %}↓{% endif %}
+                        </th>
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
+                <tbody class="align-middle">
+                    {% for score in scores %}
+                        <tr>
+                            {% if request.resolver_match.url_name == "player_most_played" %}
+                                <td class="text-nowrap">{{ score.num_scores }}</td>
+                            {% endif %}
+                            <td class="text-nowrap">
+                                {% with song=score.song %}
+                                    {% include "boogie_ui/song_link.html" %}
+                                {% endwith %}
+                            </td>
+                            <td class="text-nowrap">{{ score.comment }}</td>
+                            <td class="text-nowrap">{% include "boogie_ui/score_with_judgments.html" %}</td>
+                            <td class="text-nowrap">
+                                {% with datetime=score.submission_date %}
+                                    {% include "boogie_ui/convert_timestamp.html" %}
+                                {% endwith %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
         {% include "boogie_ui/paginator.html" %}
     {% else %}
         <p>No scores.</p>

--- a/boogiestats/templates/boogie_ui/player_update.html
+++ b/boogiestats/templates/boogie_ui/player_update.html
@@ -11,8 +11,8 @@
     Edit Profile
 {% endblock title %}
 {% block content %}
-    <h2>Edit Profile</h2>
-    <div class="w-50 p-3">
+    <div class="container">
+        <h2>Edit Profile</h2>
         <django-formset endpoint="{{ request.path }}"  csrf-token="{{ csrf_token }}">
         {% render_form form "bootstrap" field_classes="row mb-3" label_classes="col-sm-3" control_classes="col-sm-9" %}
         <button type="button"

--- a/boogiestats/templates/boogie_ui/players.html
+++ b/boogiestats/templates/boogie_ui/players.html
@@ -4,7 +4,7 @@
 {% endblock title %}
 {% block content %}
     <h2>Players</h2>
-    <div class="pt-3 pb-3">
+    <div class="my-3">
         <form class="form-inline" method="get">
             <input name="q"
                    class="form-control mr-sm-2"
@@ -16,58 +16,60 @@
     </div>
     {% if players %}
         {% include "boogie_ui/paginator.html" %}
-        <table class="table table-striped">
-            <thead class="bg-body-secondary">
-                <tr>
-                    <th scope="col" class="w-1 text-nowrap">
-                        <a href="{% url "players" %}?{% include "boogie_ui/q_parameter.html" %}">ID
-                            {% if request.resolver_match.url_name == "players" %}↓{% endif %}
-                        </a>
-                    </th>
-                    <th scope="col" class="w-100 text-nowrap">
-                        <a href="{% url "players_by_name" %}?{% include "boogie_ui/q_parameter.html" %}">Name
-                            {% if request.resolver_match.url_name == "players_by_name" %}↓{% endif %}
-                        </a>
-                    </th>
-                    <th scope="col" class="w-1 text-nowrap">
-                        <a href="{% url "players" %}?{% include "boogie_ui/q_parameter.html" %}">Joined on
-                            {% if request.resolver_match.url_name == "players" %}↓{% endif %}
-                        </a>
-                    </th>
-                    <th scope="col" class="w-1 text-nowrap">
-                        <a href="{% url "players_by_machine_tag" %}?{% include "boogie_ui/q_parameter.html" %}">Machine Tag
-                            {% if request.resolver_match.url_name == "players_by_machine_tag" %}↓{% endif %}
-                        </a>
-                    </th>
-                    <th scope="col" class="w-1 text-nowrap">
-                        <a href="{% url "players_by_scores" %}?{% include "boogie_ui/q_parameter.html" %}">#Scores
-                            {% if request.resolver_match.url_name == "players_by_scores" %}↓{% endif %}
-                        </a>
-                    </th>
-                </tr>
-            </thead>
-            <tbody class="align-middle">
-                {% for player in players %}
+        <div class="table-responsive">
+            <table class="table table-striped">
+                <thead class="bg-body-secondary">
                     <tr>
-                        <td class="text-nowrap">
-                            <a href="{% url "player" player_id=player.id %}">{{ player.id }}</a>
-                        </td>
-                        <td class="text-nowrap">
-                            <a href="{% url "player" player_id=player.id %}">{{ player.name }}</a>
-                        </td>
-                        <td class="text-nowrap">
-                            <a href="{% url "player" player_id=player.id %}">{{ player.join_date.date }}</a>
-                        </td>
-                        <td class="text-nowrap">
-                            <a href="{% url "player" player_id=player.id %}">{{ player.machine_tag }}</a>
-                        </td>
-                        <td class="text-nowrap">
-                            <a href="{% url "player" player_id=player.id %}">{{ player.num_scores }}</a>
-                        </td>
+                        <th scope="col" class="w-1 text-nowrap">
+                            <a href="{% url "players" %}?{% include "boogie_ui/q_parameter.html" %}">ID
+                                {% if request.resolver_match.url_name == "players" %}↓{% endif %}
+                            </a>
+                        </th>
+                        <th scope="col" class="w-100 text-nowrap">
+                            <a href="{% url "players_by_name" %}?{% include "boogie_ui/q_parameter.html" %}">Name
+                                {% if request.resolver_match.url_name == "players_by_name" %}↓{% endif %}
+                            </a>
+                        </th>
+                        <th scope="col" class="w-1 text-nowrap">
+                            <a href="{% url "players" %}?{% include "boogie_ui/q_parameter.html" %}">Joined on
+                                {% if request.resolver_match.url_name == "players" %}↓{% endif %}
+                            </a>
+                        </th>
+                        <th scope="col" class="w-1 text-nowrap">
+                            <a href="{% url "players_by_machine_tag" %}?{% include "boogie_ui/q_parameter.html" %}">Machine Tag
+                                {% if request.resolver_match.url_name == "players_by_machine_tag" %}↓{% endif %}
+                            </a>
+                        </th>
+                        <th scope="col" class="w-1 text-nowrap">
+                            <a href="{% url "players_by_scores" %}?{% include "boogie_ui/q_parameter.html" %}">#Scores
+                                {% if request.resolver_match.url_name == "players_by_scores" %}↓{% endif %}
+                            </a>
+                        </th>
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
+                <tbody class="align-middle">
+                    {% for player in players %}
+                        <tr>
+                            <td class="text-nowrap">
+                                <a href="{% url "player" player_id=player.id %}">{{ player.id }}</a>
+                            </td>
+                            <td class="text-nowrap">
+                                <a href="{% url "player" player_id=player.id %}">{{ player.name }}</a>
+                            </td>
+                            <td class="text-nowrap">
+                                <a href="{% url "player" player_id=player.id %}">{{ player.join_date.date }}</a>
+                            </td>
+                            <td class="text-nowrap">
+                                <a href="{% url "player" player_id=player.id %}">{{ player.machine_tag }}</a>
+                            </td>
+                            <td class="text-nowrap">
+                                <a href="{% url "player" player_id=player.id %}">{{ player.num_scores }}</a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
         {% include "boogie_ui/paginator.html" %}
     {% else %}
         <p>No players.</p>

--- a/boogiestats/templates/boogie_ui/root.html
+++ b/boogiestats/templates/boogie_ui/root.html
@@ -4,6 +4,7 @@
       data-bs-theme="{{ request.COOKIES.bs_theme|default:"light" }}">
     <head>
         <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="keywords" content="boogiestats,stepmania,groovestats" />
         <meta name="Description"
               content="A pass-through proxy for groovestats.com that records non-ranked song scores." />
@@ -21,9 +22,9 @@
         {% block head_extras %}
         {% endblock head_extras %}
     </head>
-    <body>
+    <body class="min-vh-100 d-flex flex-column">
         {% include "boogie_ui/header.html" %}
-        <div class="container-fluid">
+        <div class="container-fluid my-2">
             {% for message in messages %}<div class="alert {{ message.tags }}" role="alert">{{ message|safe }}</div>{% endfor %}
             {% block content %}
             {% endblock content %}

--- a/boogiestats/templates/boogie_ui/scores.html
+++ b/boogiestats/templates/boogie_ui/scores.html
@@ -6,44 +6,46 @@
     <h2>Scores</h2>
     {% if scores %}
         {% include "boogie_ui/paginator.html" %}
-        <table class="table table-striped">
-            <thead class="bg-body-secondary">
-                <tr>
-                    <th scope="col" class="w-1 text-nowrap">
-                        <a href="{% url "scores" %}">Submission Date
-                            {% if request.resolver_match.url_name == "scores" %}↓{% endif %}
-                        </a>
-                    </th>
-                    <th scope="col" class="w-100 text-nowrap">Song</th>
-                    <th scope="col" class="w-1 text-nowrap">
-                        <a href="{% url "highscores" %}">{{ lb_display_name }} Score
-                            {% if request.resolver_match.url_name == "highscores" %}↓{% endif %}
-                        </a>
-                    </th>
-                    <th scope="col" class="w-1 text-nowrap">Player</th>
-                </tr>
-            </thead>
-            <tbody class="align-middle">
-                {% for score in scores %}
+        <div class="table-responsive">
+            <table class="table table-striped">
+                <thead class="bg-body-secondary">
                     <tr>
-                        <td class="text-nowrap">
-                            {% with datetime=score.submission_date %}
-                                {% include "boogie_ui/convert_timestamp.html" %}
-                            {% endwith %}
-                        </td>
-                        <td>
-                            {% with song=score.song %}
-                                {% include "boogie_ui/song_link.html" %}
-                            {% endwith %}
-                        </td>
-                        <td class="text-nowrap">{% include "boogie_ui/score_with_judgments.html" %}</td>
-                        <td class="text-nowrap">
-                            <a href="{% url "player" player_id=score.player.id %}">{{ score.player.name }}</a>
-                        </td>
+                        <th scope="col" class="w-1 text-nowrap">
+                            <a href="{% url "scores" %}">Submission Date
+                                {% if request.resolver_match.url_name == "scores" %}↓{% endif %}
+                            </a>
+                        </th>
+                        <th scope="col" class="w-100 text-nowrap">Song</th>
+                        <th scope="col" class="w-1 text-nowrap">
+                            <a href="{% url "highscores" %}">{{ lb_display_name }} Score
+                                {% if request.resolver_match.url_name == "highscores" %}↓{% endif %}
+                            </a>
+                        </th>
+                        <th scope="col" class="w-1 text-nowrap">Player</th>
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
+                <tbody class="align-middle">
+                    {% for score in scores %}
+                        <tr>
+                            <td class="text-nowrap">
+                                {% with datetime=score.submission_date %}
+                                    {% include "boogie_ui/convert_timestamp.html" %}
+                                {% endwith %}
+                            </td>
+                            <td class="text-nowrap">
+                                {% with song=score.song %}
+                                    {% include "boogie_ui/song_link.html" %}
+                                {% endwith %}
+                            </td>
+                            <td class="text-nowrap">{% include "boogie_ui/score_with_judgments.html" %}</td>
+                            <td class="text-nowrap">
+                                <a href="{% url "player" player_id=score.player.id %}">{{ score.player.name }}</a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
         {% include "boogie_ui/paginator.html" %}
     {% else %}
         <p>No scores are available.</p>

--- a/boogiestats/templates/boogie_ui/scores_by_day.html
+++ b/boogiestats/templates/boogie_ui/scores_by_day.html
@@ -63,34 +63,36 @@
     <h3>{{ day }} Scores</h3>
     {% if scores %}
         {% include "boogie_ui/paginator.html" %}
-        <table class="table table-striped">
-            <thead class="bg-body-secondary">
-                <tr>
-                    <th scope="col" class="w-100 text-nowrap">Song</th>
-                    <th scope="col" class="w-1 text-nowrap">Comment</th>
-                    <th scope="col" class="w-1 text-nowrap">{{ lb_display_name }} Score</th>
-                    <th scope="col" class="w-1 text-nowrap">Submission Date ↓</th>
-                </tr>
-            </thead>
-            <tbody class="align-middle">
-                {% for score in scores %}
+        <div class="table-responsive">
+            <table class="table table-striped">
+                <thead class="bg-body-secondary">
                     <tr>
-                        <td>
-                            {% with song=score.song %}
-                                {% include "boogie_ui/song_link.html" %}
-                            {% endwith %}
-                        </td>
-                        <td class="text-nowrap">{{ score.comment }}</td>
-                        <td class="text-nowrap">{% include "boogie_ui/score_with_judgments.html" %}</td>
-                        <td class="text-nowrap">
-                            {% with datetime=score.submission_date %}
-                                {% include "boogie_ui/convert_timestamp.html" %}
-                            {% endwith %}
-                        </td>
+                        <th scope="col" class="w-100 text-nowrap">Song</th>
+                        <th scope="col" class="w-1 text-nowrap">Comment</th>
+                        <th scope="col" class="w-1 text-nowrap">{{ lb_display_name }} Score</th>
+                        <th scope="col" class="w-1 text-nowrap">Submission Date ↓</th>
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
+                <tbody class="align-middle">
+                    {% for score in scores %}
+                        <tr>
+                            <td class="text-nowrap">
+                                {% with song=score.song %}
+                                    {% include "boogie_ui/song_link.html" %}
+                                {% endwith %}
+                            </td>
+                            <td class="text-nowrap">{{ score.comment }}</td>
+                            <td class="text-nowrap">{% include "boogie_ui/score_with_judgments.html" %}</td>
+                            <td class="text-nowrap">
+                                {% with datetime=score.submission_date %}
+                                    {% include "boogie_ui/convert_timestamp.html" %}
+                                {% endwith %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
         {% include "boogie_ui/paginator.html" %}
     {% else %}
         <p>No scores.</p>

--- a/boogiestats/templates/boogie_ui/search.html
+++ b/boogiestats/templates/boogie_ui/search.html
@@ -8,35 +8,37 @@
     <h2>Song Search Results</h2>
     {% if songs %}
         {% include "boogie_ui/paginator.html" %}
-        <table class="table table-striped">
-            <thead class="bg-body-secondary">
-                <tr>
-                    <th scope="col" class="w-100 text-nowrap">Song</th>
-                    <th scope="col" class="w-1 text-nowrap">#Scores ↓</th>
-                    <th scope="col" class="w-1 text-nowrap">#Players</th>
-                    <th scope="col" class="w-1 text-nowrap">{{ lb_display_name }} Highscore</th>
-                </tr>
-            </thead>
-            <tbody class="align-middle">
-                {% for song in songs %}
+        <div class="table-responsive">
+            <table class="table table-striped">
+                <thead class="bg-body-secondary">
                     <tr>
-                        <td>{% include "boogie_ui/song_link.html" %}</td>
-                        <td class="text-nowrap">{{ song.num_scores }}</td>
-                        <td class="text-nowrap">{{ song.num_players }}</td>
-                        <td class="text-nowrap">
-                            {% if song|attr:highscore_attribute %}
-                                {% with highscore=song|attr:highscore_attribute %}
-                                    <a href="{% url "score" pk=highscore.id %}">{{ highscore|attr:lb_attribute|div:100|stringformat:".2f" }}%</a> by
-                                    <a href="{% url "player" player_id=highscore.player.id %}">{{ highscore.player.name }}</a>
-                                {% endwith %}
-                            {% else %}
-                                -
-                            {% endif %}
-                        </td>
+                        <th scope="col" class="w-100 text-nowrap">Song</th>
+                        <th scope="col" class="w-1 text-nowrap">#Scores ↓</th>
+                        <th scope="col" class="w-1 text-nowrap">#Players</th>
+                        <th scope="col" class="w-1 text-nowrap">{{ lb_display_name }} Highscore</th>
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
+                <tbody class="align-middle">
+                    {% for song in songs %}
+                        <tr>
+                            <td class="text-nowrap">{% include "boogie_ui/song_link.html" %}</td>
+                            <td class="text-nowrap">{{ song.num_scores }}</td>
+                            <td class="text-nowrap">{{ song.num_players }}</td>
+                            <td class="text-nowrap">
+                                {% if song|attr:highscore_attribute %}
+                                    {% with highscore=song|attr:highscore_attribute %}
+                                        <a href="{% url "score" pk=highscore.id %}">{{ highscore|attr:lb_attribute|div:100|stringformat:".2f" }}%</a> by
+                                        <a href="{% url "player" player_id=highscore.player.id %}">{{ highscore.player.name }}</a>
+                                    {% endwith %}
+                                {% else %}
+                                    -
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
         {% include "boogie_ui/paginator.html" %}
     {% else %}
         <p>No results.</p>

--- a/boogiestats/templates/boogie_ui/song.html
+++ b/boogiestats/templates/boogie_ui/song.html
@@ -14,20 +14,22 @@
 {% block content %}
     <h2 class="mt-2">{% include "boogie_ui/song_display_name.html" %}</h2>
     <p>Pack: {{ song.chart_info.pack_name }}</p>
-    <a href="{% url "song" song_hash=song.hash %}"
-       class="btn {% if request.resolver_match.url_name in "song,song_by_date" %}btn-success{% else %}btn-secondary{% endif %}">
-        All Scores ({{ song.scores.count }})
-    </a>
-    <a href="{% url "song_highscores" song_hash=song.hash %}"
-       class="btn {% if request.resolver_match.url_name == "song_highscores" %}btn-success{% else %}btn-secondary{% endif %}">
-        Highscores ({{ num_highscores }})
-    </a>
-    {% if user.is_authenticated %}
-        <a href="{% url 'song_by_player' song_hash=song.hash player_id=user.player.id %}"
-           class="btn {% if request.resolver_match.url_name == 'song_by_player' and user.player.id == player.id %}btn-success{% else %}btn-secondary{% endif %}">
-            My scores ({{ my_scores }})
+    <div class="d-flex flex-wrap gap-2 mb-3">
+        <a href="{% url "song" song_hash=song.hash %}"
+           class="btn {% if request.resolver_match.url_name in "song,song_by_date" %}btn-success{% else %}btn-secondary{% endif %}">
+            All Scores ({{ song.scores.count }})
         </a>
-    {% endif %}
+        <a href="{% url "song_highscores" song_hash=song.hash %}"
+           class="btn {% if request.resolver_match.url_name == "song_highscores" %}btn-success{% else %}btn-secondary{% endif %}">
+            Highscores ({{ num_highscores }})
+        </a>
+        {% if user.is_authenticated %}
+            <a href="{% url 'song_by_player' song_hash=song.hash player_id=user.player.id %}"
+               class="btn {% if request.resolver_match.url_name == 'song_by_player' and user.player.id == player.id %}btn-success{% else %}btn-secondary{% endif %}">
+                My scores ({{ my_scores }})
+            </a>
+        {% endif %}
+    </div>
     <h3>
         {% if request.resolver_match.url_name == "song" %}
             All Scores
@@ -45,52 +47,54 @@
     </h3>
     {% if song.scores %}
         {% include "boogie_ui/paginator.html" %}
-        <table class="table table-striped">
-            <thead class="bg-body-secondary">
-                <tr>
-                    <th scope="col" class="w-1 text-nowrap">
-                        {% if request.resolver_match.url_name == "song_highscores" %}
-                            {{ lb_display_name }} Highscore ↓
-                        {% elif request.resolver_match.url_name in "song,song_by_date" %}
-                            <a href="{% url "song" song_hash=song.hash %}">
-                                {{ lb_display_name }} Score
-                                {% if request.resolver_match.url_name == "song" %}↓{% endif %}
-                            </a>
-                        {% else %}
-                            {{ lb_display_name }} Score ↓
-                        {% endif %}
-                    </th>
-                    <th scope="col" class="w-1 text-nowrap">Player</th>
-                    <th scope="col" class="w-100 text-nowrap">Comment</th>
-                    <th scope="col" class="w-1 text-nowrap">
-                        {% if request.resolver_match.url_name in "song,song_by_date" %}
-                            <a href="{% url "song_by_date" song_hash=song.hash %}">
-                                Submission Date
-                                {% if request.resolver_match.url_name == "song_by_date" %}↓{% endif %}
-                            </a>
-                        {% else %}
-                            Submission Date
-                        {% endif %}
-                    </th>
-                </tr>
-            </thead>
-            <tbody class="align-middle">
-                {% for score in scores %}
+        <div class="table-responsive">
+            <table class="table table-striped">
+                <thead class="bg-body-secondary">
                     <tr>
-                        <td class="text-nowrap">{% include "boogie_ui/score_with_judgments.html" %}</td>
-                        <td class="text-nowrap">
-                            <a href="{% url "player" player_id=score.player.id %}">{{ score.player.name }}</a>
-                        </td>
-                        <td class="text-nowrap">{{ score.comment }}</td>
-                        <td class="text-nowrap">
-                            {% with datetime=score.submission_date %}
-                                {% include "boogie_ui/convert_timestamp.html" %}
-                            {% endwith %}
-                        </td>
+                        <th scope="col" class="w-1 text-nowrap">
+                            {% if request.resolver_match.url_name == "song_highscores" %}
+                                {{ lb_display_name }} Highscore ↓
+                            {% elif request.resolver_match.url_name in "song,song_by_date" %}
+                                <a href="{% url "song" song_hash=song.hash %}">
+                                    {{ lb_display_name }} Score
+                                    {% if request.resolver_match.url_name == "song" %}↓{% endif %}
+                                </a>
+                            {% else %}
+                                {{ lb_display_name }} Score ↓
+                            {% endif %}
+                        </th>
+                        <th scope="col" class="w-1 text-nowrap">Player</th>
+                        <th scope="col" class="w-100 text-nowrap">Comment</th>
+                        <th scope="col" class="w-1 text-nowrap">
+                            {% if request.resolver_match.url_name in "song,song_by_date" %}
+                                <a href="{% url "song_by_date" song_hash=song.hash %}">
+                                    Submission Date
+                                    {% if request.resolver_match.url_name == "song_by_date" %}↓{% endif %}
+                                </a>
+                            {% else %}
+                                Submission Date
+                            {% endif %}
+                        </th>
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
+                <tbody class="align-middle">
+                    {% for score in scores %}
+                        <tr>
+                            <td class="text-nowrap">{% include "boogie_ui/score_with_judgments.html" %}</td>
+                            <td class="text-nowrap">
+                                <a href="{% url "player" player_id=score.player.id %}">{{ score.player.name }}</a>
+                            </td>
+                            <td class="text-nowrap">{{ score.comment }}</td>
+                            <td class="text-nowrap">
+                                {% with datetime=score.submission_date %}
+                                    {% include "boogie_ui/convert_timestamp.html" %}
+                                {% endwith %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
         {% include "boogie_ui/paginator.html" %}
     {% else %}
         <p>No songs.</p>

--- a/boogiestats/templates/boogie_ui/songs.html
+++ b/boogiestats/templates/boogie_ui/songs.html
@@ -8,43 +8,45 @@
     <h2>Songs</h2>
     {% if songs %}
         {% include "boogie_ui/paginator.html" %}
-        <table class="table table-striped">
-            <thead class="bg-body-secondary">
-                <tr>
-                    <th scope="col" class="w-100 text-nowrap">Song</th>
-                    <th scope="col" class="w-1 text-nowrap">
-                        <a href="{% url "songs" %}">#Scores
-                            {% if request.resolver_match.url_name == "songs" %}↓{% endif %}
-                        </a>
-                    </th>
-                    <th scope="col" class="w-1 text-nowrap">
-                        <a href="{% url "songs_by_players" %}">#Players
-                            {% if request.resolver_match.url_name == "songs_by_players" %}↓{% endif %}
-                        </a>
-                    </th>
-                    <th scope="col" class="w-1 text-nowrap">{{ lb_display_name }} Highscore</th>
-                </tr>
-            </thead>
-            <tbody class="align-middle">
-                {% for song in songs %}
+        <div class="table-responsive">
+            <table class="table table-striped">
+                <thead class="bg-body-secondary">
                     <tr>
-                        <td>{% include "boogie_ui/song_link.html" %}</td>
-                        <td class="text-nowrap">{{ song.number_of_scores }}</td>
-                        <td class="text-nowrap">{{ song.number_of_players }}</td>
-                        <td class="text-nowrap">
-                            {% if song|attr:highscore_attribute %}
-                                {% with highscore=song|attr:highscore_attribute %}
-                                    <a href="{% url "score" pk=highscore.id %}">{{ highscore|attr:lb_attribute|div:100|stringformat:".2f" }}%</a> by
-                                    <a href="{% url "player" player_id=highscore.player.id %}">{{ highscore.player.name }}</a>
-                                {% endwith %}
-                            {% else %}
-                                -
-                            {% endif %}
-                        </td>
+                        <th scope="col" class="w-100 text-nowrap">Song</th>
+                        <th scope="col" class="w-1 text-nowrap">
+                            <a href="{% url "songs" %}">#Scores
+                                {% if request.resolver_match.url_name == "songs" %}↓{% endif %}
+                            </a>
+                        </th>
+                        <th scope="col" class="w-1 text-nowrap">
+                            <a href="{% url "songs_by_players" %}">#Players
+                                {% if request.resolver_match.url_name == "songs_by_players" %}↓{% endif %}
+                            </a>
+                        </th>
+                        <th scope="col" class="w-1 text-nowrap">{{ lb_display_name }} Highscore</th>
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
+                <tbody class="align-middle">
+                    {% for song in songs %}
+                        <tr>
+                            <td class="text-nowrap">{% include "boogie_ui/song_link.html" %}</td>
+                            <td class="text-nowrap">{{ song.number_of_scores }}</td>
+                            <td class="text-nowrap">{{ song.number_of_players }}</td>
+                            <td class="text-nowrap">
+                                {% if song|attr:highscore_attribute %}
+                                    {% with highscore=song|attr:highscore_attribute %}
+                                        <a href="{% url "score" pk=highscore.id %}">{{ highscore|attr:lb_attribute|div:100|stringformat:".2f" }}%</a> by
+                                        <a href="{% url "player" player_id=highscore.player.id %}">{{ highscore.player.name }}</a>
+                                    {% endwith %}
+                                {% else %}
+                                    -
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
         {% include "boogie_ui/paginator.html" %}
     {% else %}
         <p>No songs.</p>

--- a/boogiestats/templates/boogie_ui/versus.html
+++ b/boogiestats/templates/boogie_ui/versus.html
@@ -7,9 +7,9 @@
     {{ p2.name }} ({{ p2.machine_tag }})
 {% endblock title %}
 {% block content %}
-    <div class="container">
+    <div class="container mb-3">
         <div class="row">
-            <div class="col text-end">
+            <div class="col text-nowrap text-end overflow-auto">
                 <div>
                     <h2>
                         <a href="{% url "player" player_id=p1.id %}">{{ p1.name }} ({{ p1.machine_tag }})</a>
@@ -33,7 +33,7 @@
                 <div>{{ p1_wins }}</div>
                 <div>{{ ties }}</div>
             </div>
-            <div class="col-2 text-center text-nowrap">
+            <div class="col col-md-2 text-nowrap text-center">
                 <div>
                     <h2>vs</h2>
                 </div>
@@ -55,7 +55,7 @@
                 <div>Wins</div>
                 <div>Ties</div>
             </div>
-            <div class="col text-start">
+            <div class="col text-nowrap text-start overflow-auto">
                 <div>
                     <h2>
                         <a href="{% url "player" player_id=p2.id %}">{{ p2.name }} ({{ p2.machine_tag }})</a>
@@ -83,46 +83,48 @@
     </div>
     {% if scores %}
         {% include "boogie_ui/paginator.html" %}
-        <table class="table table-striped">
-            <thead class="bg-body-secondary">
-                <tr>
-                    <th scope="col" class="w-100 text-nowrap">Song</th>
-                    <th scope="col" class="w-1 text-nowrap">
-                        <a href="{% url "versus_by_difference" p1=p1.id p2=p2.id %}"> Difference (pp)
-                            {% if request.resolver_match.url_name == "versus_by_difference" %}↓{% endif %}
-                        </a>
-                    </th>
-                    <th scope="col" class="w-1 text-nowrap">
-                        <a href="{% url "versus" p1=p1.id p2=p2.id %}">{{ p1.name }} ({{ p1.machine_tag }}) {{ lb_display_name }} score
-                            {% if request.resolver_match.url_name == "versus" %}↓{% endif %}
-                        </a>
-                    </th>
-                    <th scope="col" class="w-1 text-nowrap">
-                        <a href="{% url "versus" p1=p2.id p2=p1.id %}">{{ p2.name }} ({{ p2.machine_tag }}) {{ lb_display_name }} score</a>
-                    </th>
-                </tr>
-            </thead>
-            <tbody class="align-middle">
-                {% for p1_score, p2_score in scores %}
+        <div class="table-responsive">
+            <table class="table table-striped">
+                <thead class="bg-body-secondary">
                     <tr>
-                        <td>
-                            {% with song=p1_score.song %}
-                                {% include "boogie_ui/song_link.html" %}
-                            {% endwith %}
-                        </td>
-                        {% with p1_score_value=p1_score|attr:lb_attribute p2_score_value=p2_score|attr:lb_attribute %}
-                            <td class="text-nowrap">{{ p1_score_value|sub:p2_score_value|div:100|stringformat:".2f" }}</td>
-                            <td class="text-nowrap bg-gradient {% if p1_score_value > p2_score_value %}bg-success-subtle{% elif p1_score_value == p2_score_value %}bg-warning-subtle{% else %}bg-danger-subtle{% endif %}">
-                                <a href="{% url "score" pk=p1_score.id %}">{{ p1_score_value|div:100|stringformat:".2f" }}%</a>
-                            </td>
-                            <td class="text-nowrap bg-gradient {% if p1_score_value < p2_score_value %}bg-success-subtle{% elif p1_score_value == p2_score_value %}bg-warning-subtle{% else %}bg-danger-subtle{% endif %}">
-                                <a href="{% url "score" pk=p2_score.id %}">{{ p2_score_value|div:100|stringformat:".2f" }}%</a>
-                            </td>
-                        {% endwith %}
+                        <th scope="col" class="w-100 text-nowrap">Song</th>
+                        <th scope="col" class="w-1 text-nowrap">
+                            <a href="{% url "versus_by_difference" p1=p1.id p2=p2.id %}"> Difference (pp)
+                                {% if request.resolver_match.url_name == "versus_by_difference" %}↓{% endif %}
+                            </a>
+                        </th>
+                        <th scope="col" class="w-1 text-nowrap">
+                            <a href="{% url "versus" p1=p1.id p2=p2.id %}">{{ p1.name }} ({{ p1.machine_tag }}) {{ lb_display_name }} score
+                                {% if request.resolver_match.url_name == "versus" %}↓{% endif %}
+                            </a>
+                        </th>
+                        <th scope="col" class="w-1 text-nowrap">
+                            <a href="{% url "versus" p1=p2.id p2=p1.id %}">{{ p2.name }} ({{ p2.machine_tag }}) {{ lb_display_name }} score</a>
+                        </th>
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
+                <tbody class="align-middle">
+                    {% for p1_score, p2_score in scores %}
+                        <tr>
+                            <td class="text-nowrap">
+                                {% with song=p1_score.song %}
+                                    {% include "boogie_ui/song_link.html" %}
+                                {% endwith %}
+                            </td>
+                            {% with p1_score_value=p1_score|attr:lb_attribute p2_score_value=p2_score|attr:lb_attribute %}
+                                <td class="text-nowrap">{{ p1_score_value|sub:p2_score_value|div:100|stringformat:".2f" }}</td>
+                                <td class="text-nowrap bg-gradient {% if p1_score_value > p2_score_value %}bg-success-subtle{% elif p1_score_value == p2_score_value %}bg-warning-subtle{% else %}bg-danger-subtle{% endif %}">
+                                    <a href="{% url "score" pk=p1_score.id %}">{{ p1_score_value|div:100|stringformat:".2f" }}%</a>
+                                </td>
+                                <td class="text-nowrap bg-gradient {% if p1_score_value < p2_score_value %}bg-success-subtle{% elif p1_score_value == p2_score_value %}bg-warning-subtle{% else %}bg-danger-subtle{% endif %}">
+                                    <a href="{% url "score" pk=p2_score.id %}">{{ p2_score_value|div:100|stringformat:".2f" }}%</a>
+                                </td>
+                            {% endwith %}
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
         {% include "boogie_ui/paginator.html" %}
     {% else %}
         <p>No common songs.</p>


### PR DESCRIPTION
An attempt to make frontend more mobile-friendly, changes included:
- viewport define in head section (as suggested in #31)
- header is now sticky (always shown at the top, even after scrolling)
- footer moved to the bottom
- wrapped all tables in *table-responsive* containers
- wrapped forms in containers
- *text-nowrap* applied to prevent elements from resizing vertically
- margins added
- date format shortened