### PR TITLE
Add padding to account for navbar when scrolling

### DIFF
--- a/boogiestats/static/boogie_ui/boogiestats.css
+++ b/boogiestats/static/boogie_ui/boogiestats.css
@@ -2,6 +2,10 @@
   --bs-link-color-rgb: #adb5bd;
 }
 
+html {
+  scroll-padding-top: 60px;
+}
+
 form table td {
   padding-top: 10px;
   padding-bottom: 10px;


### PR DESCRIPTION
It makes a difference when #anchors are used for scrolling the page

before:

![image](https://github.com/florczakraf/boogie-stats/assets/9034451/84d7c378-e49e-401c-8ac1-3cc6a2de1162)

after:

![image](https://github.com/florczakraf/boogie-stats/assets/9034451/91d29243-d032-4e50-aa59-b9bb90622f03)

thanks @KyRZy for suggestion in the issue

closes #184 
