### PR TITLE
WA for Expert charts missing a color

### DIFF
--- a/boogiestats/static/boogie_ui/boogiestats.css
+++ b/boogiestats/static/boogie_ui/boogiestats.css
@@ -35,6 +35,11 @@ form label {
   background-color: #2691c5;
 }
 
+/* WA for the database entries that are nor normalized to common diff names https://github.com/florczakraf/boogie-stats/issues/186 */
+.diff-expert {
+  background-color: #2691c5;
+}
+
 .diff-box {
   color: white;
 }


### PR DESCRIPTION
This is a WA for #186 until diff names are normalized in the database

Before:

![image](https://github.com/user-attachments/assets/1aded51f-1b76-4d9d-8e38-8b33ab7dd324)


After:

![image](https://github.com/user-attachments/assets/139c085b-6760-4b46-a18f-40532548c3b6)

closes #186 