### PR TITLE
Optimize score list views

### DIFF
--- a/boogiestats/boogie_ui/views.py
+++ b/boogiestats/boogie_ui/views.py
@@ -94,12 +94,12 @@ class ScoreListView(LeaderboardSourceMixin, generic.ListView):
     paginate_by = ENTRIES_PER_PAGE
 
     def get_queryset(self):
-        return Score.objects.order_by("-submission_date").select_related("song", "player")
+        return Score.objects.order_by("-submission_date").prefetch_related("song", "player")
 
 
 class HighscoreListView(ScoreListView):
     def get_queryset(self):
-        return Score.objects.order_by(f"-{self.lb_attribute}", "submission_date").select_related("song", "player")
+        return Score.objects.order_by(f"-{self.lb_attribute}", "submission_date").prefetch_related("song", "player")
 
 
 class PlayersListView(generic.ListView):


### PR DESCRIPTION
Even though there are proper indices in the db, some of the queries are going to be slow when we have to scan and discard a lot of rows. This is the case when we try to access high page numbers of score and highscore lists. The latter is even more problematic, because it orders the rows by two indices.

This PR is not a solution but somewhat a WA for the time being. We will have to think of reworking the scores list, for example by limiting public views to the last month of scores or some N scores to prevent web scrapers and indexing bots from draining the server resources.

before:  
![image](https://github.com/user-attachments/assets/35cd5d42-9f7a-4163-9eae-3ab47b7c2bb0)

after:  
![image](https://github.com/user-attachments/assets/2c525f46-7f50-4b04-8f1f-21a4296cb187)
