### PR TITLE
Remove sorting all submissions by score

### DIFF
--- a/boogiestats/boogie_ui/urls.py
+++ b/boogiestats/boogie_ui/urls.py
@@ -35,7 +35,6 @@ urlpatterns = [
     path("songs/<str:song_hash>/highscores", views.SongHighscoresView.as_view(), name="song_highscores"),
     path("scores/", views.ScoreListView.as_view(), name="scores"),
     path("scores/<int:pk>/", views.ScoreView.as_view(), name="score"),
-    path("scores/highscores", views.HighscoreListView.as_view(), name="highscores"),
     path("edit/", views.EditPlayerView.as_view(), name="edit"),
     path("login/", views.login_user, name="login"),
     path("logout/", views.logout_user, name="logout"),

--- a/boogiestats/boogie_ui/views.py
+++ b/boogiestats/boogie_ui/views.py
@@ -97,11 +97,6 @@ class ScoreListView(LeaderboardSourceMixin, generic.ListView):
         return Score.objects.order_by("-submission_date").prefetch_related("song", "player")
 
 
-class HighscoreListView(ScoreListView):
-    def get_queryset(self):
-        return Score.objects.order_by(f"-{self.lb_attribute}", "submission_date").prefetch_related("song", "player")
-
-
 class PlayersListView(generic.ListView):
     template_name = "boogie_ui/players.html"
     context_object_name = "players"

--- a/boogiestats/templates/boogie_ui/scores.html
+++ b/boogiestats/templates/boogie_ui/scores.html
@@ -10,17 +10,9 @@
             <table class="table table-striped">
                 <thead class="bg-body-secondary">
                     <tr>
-                        <th scope="col" class="w-1 text-nowrap">
-                            <a href="{% url "scores" %}">Submission Date
-                                {% if request.resolver_match.url_name == "scores" %}↓{% endif %}
-                            </a>
-                        </th>
+                        <th scope="col" class="w-1 text-nowrap">Submission Date ↓</th>
                         <th scope="col" class="w-100 text-nowrap">Song</th>
-                        <th scope="col" class="w-1 text-nowrap">
-                            <a href="{% url "highscores" %}">{{ lb_display_name }} Score
-                                {% if request.resolver_match.url_name == "highscores" %}↓{% endif %}
-                            </a>
-                        </th>
+                        <th scope="col" class="w-1 text-nowrap">{{ lb_display_name }} Score</th>
                         <th scope="col" class="w-1 text-nowrap">Player</th>
                     </tr>
                 </thead>


### PR DESCRIPTION
It's no longer needed since we've got so many good players around that there are several pages of quints and quads. Player list offers sorting by the number of quints and quads that can give more insights.

Moreover, the sorting over two indices (first score, then date) was not performing very well for high page numbers, because the database engine would have to sort and drop all the data that comes before the requested page.

![image](https://github.com/user-attachments/assets/a2fe3c12-b8c7-4551-ba94-8a49c2652d38)
