### PR TITLE
Fix calculations for yearly stats

### DIFF
--- a/boogiestats/templates/boogie_ui/player_wrapped.html
+++ b/boogiestats/templates/boogie_ui/player_wrapped.html
@@ -1,5 +1,6 @@
 {% extends "boogie_ui/root.html" %}
 {% load mathfilters %}
+{% load bootstrap_icons %}
 {% block title %}
     {{ player.name }} ({{ player.machine_tag }}) {{ year }} Wrapped
 {% endblock title %}
@@ -52,7 +53,15 @@
                 {% endif %}
             </ul>
         </div>
-        {% include "boogie_ui/stars.html" %}
+        <div class="col">
+            {% include "boogie_ui/stars.html" %}
+            <button type="button"
+                    class="btn btn-outline-secondary"
+                    data-bs-toggle="tooltip"
+                    title="Wrapped stars include all submitted scores that match the criteria, not only the top ones for each chart.">
+                {% bs_icon "question-circle" %}
+            </button>
+        </div>
     </div>
     <hr />
     {% include "boogie_ui/calendar.html" %}


### PR DESCRIPTION
Unique charts used the wrong formula. Stars were inaccurate as well but I couldn't find a neat way to calculate them the same way as in global stats where only the top score for each chart is considered, so they now include duplicates. However, there's a help button with an explanation below

before:

![image](https://github.com/user-attachments/assets/dfa88cb3-51cd-48e6-90a1-0e6cbae8d609)

after:

![image](https://github.com/user-attachments/assets/d0677c8d-15ae-492e-8fec-8ac9bb93b040)

![image](https://github.com/user-attachments/assets/9def107e-2664-4f44-b975-aee6d7c97409)


closes #199 
