### PR TITLE
Pin poetry to 1.* series

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install poetry
+          pip install poetry==1.*
           poetry install
       - name: Test with pytest
         run: |
@@ -35,7 +35,7 @@ jobs:
           python-version: "3.10"
       - name: Install dependencies
         run: |
-          pip install poetry
+          pip install poetry==1.*
           poetry install
       - name: pre-commit checks
         run: |


### PR DESCRIPTION
Poetry recently released series 2 which breaks some compatibility. Let's stick to 1.* for some time.

This fixes `poetry check` in the pipeline: https://github.com/florczakraf/boogie-stats/actions/runs/12715880761/job/35448987245