### PR TITLE
Increase GS timeouts

### DIFF
--- a/boogiestats/boogie_api/views.py
+++ b/boogiestats/boogie_api/views.py
@@ -40,7 +40,7 @@ GROOVESTATS_RESPONSES = {
         "error": "Couldn't contact GrooveStats API.",
     },
 }
-GROOVESTATS_TIMEOUT = (4, 6)  # (connect, read) timeout
+GROOVESTATS_TIMEOUT = (5, 20)  # (connect, read) timeout
 SUPPORTED_EVENTS = ("rpg", "itl")
 LB_SOURCE_MAPPING = {
     LeaderboardSource.BS.value: "BS",


### PR DESCRIPTION
GS performs terribly since the start of ITL2025, this PR is hopefully a temporary WA for that that will allow more score submissions go through while they work on improving their service.