### PR TITLE
calendar: Only link days with plays

### DIFF
--- a/boogiestats/templates/boogie_ui/calendar.html
+++ b/boogiestats/templates/boogie_ui/calendar.html
@@ -13,7 +13,7 @@
                 </div>
             {% endfor %}
             {% for day in calendar_days %}
-                <a href="{% url "player_scores_by_day" player_id=player.id day=day.day %}"
+                <a {% if day.plays > 0 %}href="{% url "player_scores_by_day" player_id=player.id day=day.day %}"{% endif %}
                    class="calendar-graph-box {{ day.class }}"
                    data-bs-toggle="tooltip"
                    title="{{ day.day }}: {{ day.plays }}">


### PR DESCRIPTION
Hovers still work so you can see the actual date for each field on the grid 

<img width="141" height="104" alt="image" src="https://github.com/user-attachments/assets/c76f0889-46f3-40a1-85f8-0e9f2c0bf74c" />

closes #221 