### PR TITLE
Add a client option to bypass upstream submission

### DIFF
--- a/boogiestats/boogie_api/test/test_api.py
+++ b/boogiestats/boogie_api/test/test_api.py
@@ -16,6 +16,7 @@ from boogiestats.boogie_api.models import (
     Song,
 )
 from boogiestats.boogie_api.views import (
+    BYPASS_UPSTREAM_HEADER,
     GROOVESTATS_RESPONSES,
     LB_SOURCE_MAPPING,
     create_headers,
@@ -1611,6 +1612,132 @@ def test_score_submit_when_gs_timeouts_for_two_players(
 ):
     Player.objects.create(gs_api_key=gs_api_key, machine_tag="p1", gs_integration=p1_gs_integration)
     Player.objects.create(gs_api_key=other_player_gs_api_key, machine_tag="p2", gs_integration=p2_gs_integration)
+
+    requests_mock.post(GROOVESTATS_ENDPOINT + "/score-submit.php", exc=requests.Timeout)
+    kwargs = {
+        "HTTP_x_api_key_player_1": gs_api_key,
+        "HTTP_x_api_key_player_2": other_player_gs_api_key,
+    }
+    chart_hash = "76957dd1f96f764e"
+    response = client.post(
+        f"/score-submit.php?chartHashP1={chart_hash}&chartHashP2={chart_hash}&maxLeaderboardResults=3",
+        data={
+            "player1": {
+                "score": 10_000,
+                "comment": "",
+                "judgmentCounts": {
+                    "fantasticPlus": 1,
+                    "totalSteps": 1,
+                },
+                "rate": 100,
+            },
+            "player2": {
+                "score": 5_000,
+                "comment": "",
+                "judgmentCounts": {
+                    "fantastic": 1,
+                    "totalSteps": 1,
+                },
+                "rate": 100,
+            },
+        },
+        content_type="application/json",
+        **kwargs,
+    )
+
+    assert response.status_code == response_status_code
+    assert (requests_mock.call_count == 1) is submission_attempted
+    assert Score.objects.count() == num_scores
+
+    if response_status_code == 200:
+        assert response.headers["bs-gs-integration-1"] == p1_gs_integration.label
+        assert response.headers["bs-gs-integration-2"] == p2_gs_integration.label
+
+
+@pytest.mark.parametrize(
+    ("p1_gs_integration", "p2_gs_integration", "num_scores", "submission_attempted", "response_status_code"),
+    [
+        (GSIntegration.REQUIRE, GSIntegration.REQUIRE, 2, False, 200),
+        (GSIntegration.REQUIRE, GSIntegration.TRY, 2, False, 200),
+        (GSIntegration.REQUIRE, GSIntegration.SKIP, 2, False, 200),
+        (GSIntegration.TRY, GSIntegration.TRY, 2, False, 200),
+        (GSIntegration.TRY, GSIntegration.SKIP, 2, False, 200),
+        (GSIntegration.SKIP, GSIntegration.SKIP, 2, False, 200),
+    ],
+)
+def test_score_submit_with_upstream_bypass_header_when_players_exist(
+    client,
+    gs_api_key,
+    other_player_gs_api_key,
+    p1_gs_integration,
+    p2_gs_integration,
+    num_scores,
+    submission_attempted,
+    response_status_code,
+    requests_mock,
+):
+    Player.objects.create(gs_api_key=gs_api_key, machine_tag="p1", gs_integration=p1_gs_integration)
+    Player.objects.create(gs_api_key=other_player_gs_api_key, machine_tag="p2", gs_integration=p2_gs_integration)
+
+    requests_mock.post(GROOVESTATS_ENDPOINT + "/score-submit.php", exc=requests.Timeout)
+    kwargs = {
+        "HTTP_x_api_key_player_1": gs_api_key,
+        "HTTP_x_api_key_player_2": other_player_gs_api_key,
+        f"HTTP_{BYPASS_UPSTREAM_HEADER.replace('-', '_')}": "1",
+    }
+    chart_hash = "76957dd1f96f764e"
+    response = client.post(
+        f"/score-submit.php?chartHashP1={chart_hash}&chartHashP2={chart_hash}&maxLeaderboardResults=3",
+        data={
+            "player1": {
+                "score": 10_000,
+                "comment": "",
+                "judgmentCounts": {
+                    "fantasticPlus": 1,
+                    "totalSteps": 1,
+                },
+                "rate": 100,
+            },
+            "player2": {
+                "score": 5_000,
+                "comment": "",
+                "judgmentCounts": {
+                    "fantastic": 1,
+                    "totalSteps": 1,
+                },
+                "rate": 100,
+            },
+        },
+        content_type="application/json",
+        **kwargs,
+    )
+
+    assert response.status_code == response_status_code
+    assert (requests_mock.call_count == 1) is submission_attempted
+    assert Score.objects.count() == num_scores
+    assert response.headers["bs-gs-integration-1"] == p1_gs_integration.label
+    assert response.headers["bs-gs-integration-2"] == p2_gs_integration.label
+
+
+@pytest.mark.parametrize(
+    ("p1_gs_integration", "num_scores", "submission_attempted", "response_status_code"),
+    [
+        (GSIntegration.REQUIRE, 0, True, 504),
+        (GSIntegration.TRY, 0, True, 504),
+        (GSIntegration.SKIP, 0, True, 504),
+    ],
+)
+def test_score_submit_with_upstream_bypass_header_when_player_doesnt_exist(
+    client,
+    gs_api_key,
+    other_player_gs_api_key,
+    p1_gs_integration,
+    num_scores,
+    submission_attempted,
+    response_status_code,
+    requests_mock,
+):
+    Player.objects.create(gs_api_key=gs_api_key, machine_tag="p1", gs_integration=p1_gs_integration)
 
     requests_mock.post(GROOVESTATS_ENDPOINT + "/score-submit.php", exc=requests.Timeout)
     kwargs = {

--- a/boogiestats/boogie_api/views.py
+++ b/boogiestats/boogie_api/views.py
@@ -57,6 +57,7 @@ GROOVESTATS_RESPONSES = {
     },
 }
 API_KEY_HEADER_PREFIX = "x-api-key-player-"
+BYPASS_UPSTREAM_HEADER = "bs-bypass-upstream"
 GROOVESTATS_TIMEOUT = (4, 6)  # (connect, read) timeout
 SUPPORTED_EVENTS = ("rpg", "itl")
 LB_SOURCE_MAPPING = {
@@ -367,10 +368,14 @@ def score_submit(request):
     max_results = int(request.GET.get("maxLeaderboardResults", 1))
 
     player_instances = [p["player_instance"] for p in players.values()]
-    # if player doesn't exist we need to call GS to verify the key for the first time
-    gs_integrations = [p and p.gs_integration or GSIntegration.REQUIRE for p in player_instances]
-    should_attempt_gs = any(g != GSIntegration.SKIP for g in gs_integrations)
-    require_gs = any(g == GSIntegration.REQUIRE for g in gs_integrations)
+    if all(player_instances) and request.headers.get(BYPASS_UPSTREAM_HEADER):
+        should_attempt_gs = False
+        require_gs = False
+    else:
+        # if player doesn't exist we need to call GS to verify the key for the first time
+        gs_integrations = [p and p.gs_integration or GSIntegration.REQUIRE for p in player_instances]
+        should_attempt_gs = any(g != GSIntegration.SKIP for g in gs_integrations)
+        require_gs = any(g == GSIntegration.REQUIRE for g in gs_integrations)
 
     gs_response = {}
     if should_attempt_gs:


### PR DESCRIPTION
(rebased on #244)

Until now the submitting client couldn't alter the behavior of the upstream score submission. This adds a new header: `bs-bypass-upstream` that overrides players' configs when present and both players have an account.

cc @simplyviper16