### PR TITLE
Unlocalize player ID for twitch live status check

### DIFF
--- a/boogiestats/templates/boogie_ui/twitch_live_badge.html
+++ b/boogiestats/templates/boogie_ui/twitch_live_badge.html
@@ -4,7 +4,7 @@
            href="https://www.twitch.tv/{{ player.twitch_handle }}"
            target="_blank">live</a>
         {% if player.is_live_cached == None %}
-            <span class="visually-hidden check-live-status">{{ player.id }}</span>
+            <span class="visually-hidden check-live-status">{{ player.id|unlocalize }}</span>
         {% endif %}
     </span>
 {% endif %}


### PR DESCRIPTION
player IDs over 1k ended up making requests like `/api/v1/live-on-twitch/1,233/` instead of `/api/v1/live-on-twitch/1233/` after #231 