### PR TITLE
Make RequireAuthForPaginationMixin configurable

### DIFF
--- a/boogiestats/boogie_ui/views.py
+++ b/boogiestats/boogie_ui/views.py
@@ -59,11 +59,10 @@ def diff_sort_key(x):
 
 
 class RequireAuthForPaginationMixin:
-    PAGES_FOR_ANONYMOUS = 3
-
     def dispatch(self, request, *args, **kwargs):
         page_num = int(request.GET.get("page", 1))
-        if page_num > self.PAGES_FOR_ANONYMOUS and not request.user.is_authenticated:
+        limit = settings.BS_PAGES_FOR_ANONYMOUS
+        if limit and page_num > limit and not request.user.is_authenticated:
             return redirect(f"{reverse('login')}?next={request.path}?page={page_num}")
 
         return super().dispatch(request, *args, **kwargs)

--- a/boogiestats/boogiestats/settings.py
+++ b/boogiestats/boogiestats/settings.py
@@ -181,3 +181,7 @@ BS_UPSTREAM_API_ENDPOINT_DISPATCHER = "https://apiservice.groovestats.com/api"
 # Score creation retry configuration (might be useful for sqlite deployments)
 BS_SCORE_CREATION_ATTEMPTS: int = 10
 BS_SCORE_CREATION_RETRY_STRATEGY: wait_base = wait_exponential_jitter(initial=0.01, max=1.0, jitter=0.05)
+
+# Limit the number of pages available to logged-out users to prevent automatic scrappers from abusing the service.
+# Set to `None` to disable the limit.
+BS_PAGES_FOR_ANONYMOUS: int | None = 3


### PR DESCRIPTION
this is built on top of #249 

This PR adds a new setting `BS_PAGES_FOR_ANONYMOUS` that controls the previously hardcoded value used by `RequireAuthForPaginationMixin` that is used to limit the access to higher pages of scores and songs in order to prevent scrappers from abusing the service.

It can be also set to `None` to disable the limit.

cc @phantom10111

Closes #248 